### PR TITLE
Get a list of the authenticated providers

### DIFF
--- a/src/Ollieread/Multiauth/MultiManager.php
+++ b/src/Ollieread/Multiauth/MultiManager.php
@@ -23,6 +23,10 @@ class MultiManager {
 		}
 	}
 	
+	/**
+	 * [getAuthenticatedTypes Gives you an array which just includes the names of the providers currently authenticated]
+	 * @return [array] [the authenticated providers]
+	 */
 	public function getAuthenticatedTypes() {
 		$authenticated = array();
 		


### PR DESCRIPTION
Hey,
I'm using your package for an app where I have to separate different user types based on different tables and not an column which indicates the user type.

In some cases I need to check with which provider the user is authenticated and then generate a proper link or so. So i added this method which checks all providers and returns an array with the authenticated ones.

Maybe you find it useful :)
