### PR TITLE
Fix bug when using custom Auth driver

### DIFF
--- a/src/Ollieread/Multiauth/AuthManager.php
+++ b/src/Ollieread/Multiauth/AuthManager.php
@@ -1,5 +1,6 @@
 <?php namespace Ollieread\Multiauth;
 
+use Illuminate\Support\Manager;
 use Illuminate\Auth\AuthManager as OriginalAuthManager;
 use Illuminate\Auth\DatabaseUserProvider;
 use Illuminate\Auth\EloquentUserProvider;
@@ -26,7 +27,7 @@ class AuthManager extends OriginalAuthManager {
 	}
 	
 	protected function callCustomCreator($driver) {
-		$custom = parent::callCustomCreator($driver);
+		$custom = Manager::callCustomCreator($driver);
 
 		if ($custom instanceof Guard) return $custom;
 


### PR DESCRIPTION
When attempting to use a custom Auth driver, an error is thrown due to an incorrect check in the `callCustomCreator` method that's been overridden in the customised `AuthManager` class.

This is because `parent::callCustomCreator($driver);` will return an instance of `Illuminate\Auth\Guard`, and consequently the `instanceof` check will fail. In order to ensure that the correct `Guard` class is created (and that the `instanceof` check passes), I've had to put in a call directly to the `Illuminate\Support\Manager` class. This is a bit dirty but is unfortunately the only workaround with the way the code is structured.
