### PR TITLE
Documentation for setting the current user in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ And so on and so forth.
 
 There we go, done! Enjoy yourselves.
 
+## Testing ##
+
+Laravel integration/controller testing implements `$this->be($user)` to the base TestCase class. The implementation of #be() does not work correctly with Multiauth. To get around this, implement your own version of #be() as follows:
+
+    public function authenticateAs($type, $user) {
+      $this->app['auth']->$type()->setUser($user);
+    }
+
+
 ### License
 
 This package inherits the licensing of its parent framework, Laravel, and as such is open-sourced 


### PR DESCRIPTION
Ran in to this problem while moving from the built in authentication to multiauth.

The implementation in the Foundation TestCase is here:
https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/Testing/TestCase.php#L404

Backwards compatibility could be hacked in by adding a #driver() function on MultiManager.php to handle searching by key, but that seems like a bit of a hack just to make testing a bit nicer but I'm open to suggestions. For now I can add some documentation to get people pointed in the right direction.
