### PR TITLE
Update MultiManager.php

### DIFF
--- a/src/Ollieread/Multiauth/MultiManager.php
+++ b/src/Ollieread/Multiauth/MultiManager.php
@@ -1,14 +1,21 @@
 <?php namespace Ollieread\Multiauth;
 
+use Illuminate\Foundation\Application;
+
 class MultiManager {
 	
+	
+	/**
+	 * @var Illuminate\Foundation\Application $app
+	 */
+	 
 	protected $app;
 	
 	protected $config;
 	
 	protected $providers = array();
 	
-	public function __construct($app) {
+	public function __construct(Application $app) {
 		$this->app = $app;
 		$this->config = $this->app['config']['auth.multi'];
 		


### PR DESCRIPTION
When using automatic resolution instead of facades, the ioc container won't be able to find the $app depency when there's no namespace.
