### PR TITLE
Mockery unable to mock Auth

### DIFF
--- a/src/Ollieread/Multiauth/MultiManager.php
+++ b/src/Ollieread/Multiauth/MultiManager.php
@@ -24,7 +24,7 @@ class MultiManager {
 		}
 	}
 	
-	public function __call($name, $arguments = array()) {
+	public function __call($name, $arguments) {
 		if(array_key_exists($name, $this->providers)) {
 			return $this->providers[$name];
 		}


### PR DESCRIPTION
When mocking the Auth facade in laravel with mockery, I received the following error

> ErrorException: Declaration of Mockery_5_Ollieread_Multiauth_MultiManager::__call() should be compatible with Ollieread\Multiauth\MultiManager::__call($name, $arguments = Array)

Since the arguments in the __call() method isn't used, we can remove the default value.
